### PR TITLE
Loosen contraints for tweakwise module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "OSL-3.0",
     "require": {
         "php": ">=8.0 <8.3",
-        "tweakwise/magento2-tweakwise": "^5.7.4",
+        "tweakwise/magento2-tweakwise": "^5.7",
         "emico/m2-attributelanding": "^4.0"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Constraint is set to only allow patch upgrade.
This constraints causes the module to not be installed together with tweakwise 5.8.x module. I think it's perfectly fine for this module to allow for minor version until 6.x