### PR TITLE
fix: Incorrect URL in Attribute Landing Page Filter Link

### DIFF
--- a/src/Plugin/UrlPlugin.php
+++ b/src/Plugin/UrlPlugin.php
@@ -79,7 +79,7 @@ class UrlPlugin
         }
 
         if ($url = $this->filterManager->findLandingPageUrlForFilterItem($filterItem)) {
-            return '/' . $url;
+            return $url;
         }
 
         return $proceed($filterItem);


### PR DESCRIPTION
Issue:
The filter link for an Attribute Landing Page (ALP) is currently generating an incorrect URL.

How to Reproduce:
1. Ensure that the setting Stores->Configuration->Emico Extensions->Attribute LandingPages->Allow Crosslink is set to Yes.
2. Create an ALP with a filter based on a category that is selectable in the shop.
3. Set Allow link in faceted search to Yes for the ALP.
4. Empty cache.
5. Navigate to the category used for the ALP in the shop and verify the link for the filter configured in the ALP. Notice that the filter link has the domain name repeated twice in the URL.

How to Test:
1. Follow the same steps as above.
2. Verify that the filter link is now correct and does not contain duplicate domain names in the URL.