### PR TITLE
fix: save tweakwise filter template

### DIFF
--- a/src/view/adminhtml/web/js/filter-attributes.js
+++ b/src/view/adminhtml/web/js/filter-attributes.js
@@ -117,7 +117,6 @@ define([
             });
 
             //select different filter template
-            $('select[name="tweakwise_filter_template"]').unbind('change');
             $('select[name="tweakwise_filter_template"]').on('change', function(evt) {
                 $('select[name*="[attribute-tmp]"]').trigger('initAttributes');
             });


### PR DESCRIPTION
This pull request addresses an issue where the field "filter template" wasn't getting saved when one or more filters were selected. The proposed changes ensure that the field is properly saved in such cases.