### PR TITLE
Make installable on PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "4.3.1",
     "require": {
         "php": ">=8.0",
-        "tweakwise/magento2-tweakwise": "^5.7.4",
+        "tweakwise/magento2-tweakwise": "^5.7.4|^6.0",
         "emico/m2-attributelanding": "^4.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Provides compatibility between Attribute landing module and Tweakwise module.",
     "license": "OSL-3.0",
     "require": {
-        "php": ">=8.0",
+        "php": "^8.0",
         "tweakwise/magento2-tweakwise": ">=5.7.4",
         "emico/m2-attributelanding": ">=4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "OSL-3.0",
     "version": "4.3.1",
     "require": {
-        "php": ">=8.0 <8.3",
+        "php": ">=8.0",
         "tweakwise/magento2-tweakwise": "^5.7.4",
         "emico/m2-attributelanding": "^4.1"
     },


### PR DESCRIPTION
New PHP subversions hardly ever break, remove the hard upper version constraint.