### PR TITLE
Fix: return landingpage url

### DIFF
--- a/src/Plugin/Block/LayeredNavigation/RenderLayered/RendererPlugin.php
+++ b/src/Plugin/Block/LayeredNavigation/RenderLayered/RendererPlugin.php
@@ -20,7 +20,7 @@ class RendererPlugin
     /**
      * @var LandingPageContext
      */
-    protected readonly LandingPageContext $landingPageContext;
+    protected $landingPageContext;
 
     /**
      * DefaultRendererPlugin constructor.

--- a/src/Plugin/Block/LayeredNavigation/RenderLayered/RendererPlugin.php
+++ b/src/Plugin/Block/LayeredNavigation/RenderLayered/RendererPlugin.php
@@ -20,7 +20,7 @@ class RendererPlugin
     /**
      * @var LandingPageContext
      */
-    protected $landingPageContext;
+    protected readonly LandingPageContext $landingPageContext;
 
     /**
      * DefaultRendererPlugin constructor.

--- a/src/Plugin/Block/LayeredNavigation/RenderLayered/RendererPlugin.php
+++ b/src/Plugin/Block/LayeredNavigation/RenderLayered/RendererPlugin.php
@@ -2,6 +2,7 @@
 
 namespace Tweakwise\AttributeLandingTweakwise\Plugin\Block\LayeredNavigation\RenderLayered;
 
+use Emico\AttributeLanding\Model\LandingPageContext;
 use Tweakwise\AttributeLandingTweakwise\Model\FilterManager;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Filter\Item;
 use Magento\Framework\View\Element\Template;
@@ -17,12 +18,18 @@ class RendererPlugin
     protected $filterManager;
 
     /**
+     * @var LandingPageContext
+     */
+    protected $landingPageContext;
+
+    /**
      * DefaultRendererPlugin constructor.
      * @param FilterManager $filterManager
      */
-    public function __construct(FilterManager $filterManager)
+    public function __construct(FilterManager $filterManager, LandingPageContext $landingPageContext)
     {
         $this->filterManager = $filterManager;
+        $this->landingPageContext = $landingPageContext;
     }
 
     /**
@@ -36,7 +43,18 @@ class RendererPlugin
         string $result,
         Item $filterItem
     ) {
-        if (!$this->filterManager->findLandingPageUrlForFilterItem($filterItem)) {
+
+        $returnToDefaultPage = false;
+
+        $landingPage = $this->landingPageContext->getLandingPage();
+        if ($landingPage) {
+            $landingPageUrl = $landingPage->getUrlPath();
+            if (stripos($result, $landingPageUrl) === false) {
+                $returnToDefaultPage = true;
+            }
+        }
+
+        if (!$this->filterManager->findLandingPageUrlForFilterItem($filterItem) && !$returnToDefaultPage) {
             return $result;
         }
 

--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -206,6 +206,5 @@ class PathSlugStrategyPlugin
         }
 
         return $landingPage->getUrlPath();
-
     }
 }

--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -201,6 +201,10 @@ class PathSlugStrategyPlugin
             return $result;
         }
 
+        if (strpos($result, $landingPage->getUrlPath()) !== false) {
+            return $result;
+        }
+
         return $this->urlFactory->create()->addBaseUrl($landingPage->getUrlPath());
     }
 }

--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -205,6 +205,7 @@ class PathSlugStrategyPlugin
             return $result;
         }
 
-        return $this->urlFactory->create()->addBaseUrl($landingPage->getUrlPath());
+        return $landingPage->getUrlPath();
+
     }
 }

--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -196,6 +196,11 @@ class PathSlugStrategyPlugin
      */
     public function afterGetOriginalUrl(PathSlugStrategy $original, string $result, MagentoHttpRequest $request): string
     {
-        return $result;
+        $landingPage = $this->landingPageContext->getLandingPage();
+        if ($landingPage === null) {
+            return $result;
+        }
+
+        return $this->urlFactory->create()->addBaseUrl($landingPage->getUrlPath());
     }
 }

--- a/src/Plugin/UrlPlugin.php
+++ b/src/Plugin/UrlPlugin.php
@@ -116,7 +116,9 @@ class UrlPlugin
         if (preg_match('|' . $landingPage->getUrlRewriteRequestPath() . '(.*)|', $removeUrl, $matches)) {
             $category = $this->getLayer()->getCurrentCategory();
             $categoryUrl = $category->getUrl();
-            $removeUrl = $categoryUrl . $matches[1];
+
+            //ensure there is one slash between category and the rest of the url
+            $removeUrl = rtrim($categoryUrl, '/') . '/' . ltrim($matches[1], '/');
         }
 
         return $removeUrl;


### PR DESCRIPTION
When you use an landingpage for an filter, and use the same url for the landingpage the returned url is not correct. This pull request fixes that.

For example. If you have an ALP configured for the category shoes. With the filter brand = nike. And you make the url of the landingpage /shoes/brand/nike

This causes the url of the page to be incorrect after selecting nike on the brand filter (category shoes). And if you select 2 filters it's impossible to disable the first filter.

How to test
- Enable ajax
- Enable Url path slug strategy
- Make an ALP with an filter. And make the url of the ALP the same as the filter url it replaces
- Make sure the ALP has  Allow link in faceted search enabled.