### PR TITLE
Fix: bump php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Provides compatibility between Attribute landing module and Tweakwise module.",
     "license": "OSL-3.0",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "tweakwise/magento2-tweakwise": ">=5.7.4",
         "emico/m2-attributelanding": ">=4.1"
     },


### PR DESCRIPTION
Bump minimum php version to 8.1. Php 8.1 is needed since the recommendation changes, but it wasn't updated in the composer.json.