### PR TITLE
feat: builder-template

### DIFF
--- a/src/Model/FilterApplier/TweakwiseFilterApplier.php
+++ b/src/Model/FilterApplier/TweakwiseFilterApplier.php
@@ -50,6 +50,11 @@ class TweakwiseFilterApplier implements FilterApplierInterface
         if ($sortTemplateId) {
             $navigationRequest->setSortTemplateId($sortTemplateId);
         }
+
+        $builderTemplateId = $page->getTweakwiseBuilderTemplate();
+        if (!empty($builderTemplateId)) {
+            $navigationRequest->setBuilderTemplateId($builderTemplateId);
+        }
     }
 
     /**

--- a/src/Model/FilterApplier/TweakwiseFilterApplier.php
+++ b/src/Model/FilterApplier/TweakwiseFilterApplier.php
@@ -52,7 +52,7 @@ class TweakwiseFilterApplier implements FilterApplierInterface
         }
 
         $builderTemplateId = $page->getTweakwiseBuilderTemplate();
-        if (!empty($builderTemplateId)) {
+        if ($builderTemplateId) {
             $navigationRequest->setBuilderTemplateId($builderTemplateId);
         }
     }

--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
@@ -119,6 +119,30 @@
 					</settings>
 				</actionDelete>
 			</container>
-		</dynamicRows>
+        </dynamicRows>
+
+        <field formElement="select" name="tweakwise_builder_template" sortOrder="66">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">Page</item>
+                </item>
+            </argument>
+
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Tweakwise builder template</label>
+                <dataScope>tweakwise_builder_template</dataScope>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">false</rule>
+                </validation>
+            </settings>
+            <formElements>
+                <select>
+                    <settings>
+                        <options class="Tweakwise\Magento2Tweakwise\Model\Config\Source\BuilderTemplate" />
+                    </settings>
+                </select>
+            </formElements>
+        </field>
 	</fieldset>
 </form>


### PR DESCRIPTION
Add builder template selection to ALP's.

Requires: https://github.com/EmicoEcommerce/Magento2AttributeLanding/pull/102 and https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/245 to work

This sets the tn_b parameter for ALP requests. https://docs.tweakwise.com/reference/navigation-3