### PR TITLE
Fix: incorrect parameter error

### DIFF
--- a/src/Model/FilterFormInputProvider/LandingPageInputProvider.php
+++ b/src/Model/FilterFormInputProvider/LandingPageInputProvider.php
@@ -79,7 +79,7 @@ class LandingPageInputProvider implements FilterFormInputProviderInterface
 
         $input = [
             '__tw_ajax_type' => self::TYPE,
-            '__tw_object_id' => (string)$page->getPageId(),
+            '__tw_object_id' => (int)$page->getPageId(),
             '__tw_original_url' => (string)$url,
         ];
 


### PR DESCRIPTION
Fixed an issue with ajax request on landingpages trowing an incorrect parameters error.

How to test

- Enable ajax navigation in the magento tweakwise settings
- Enable query parameter strategy
- Go to an landingpage
- Klik on an filter
- See that the requested ajax page returns an 200 request instead of an error