### PR TITLE
fix: alp slug

### DIFF
--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -15,6 +15,7 @@ use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\FilterSlugManag
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\PathSlugStrategy;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\UrlFactory;
 use Magento\Framework\App\Request\Http as MagentoHttpRequest;
+use Magento\Store\Model\StoreManagerInterface;
 
 class PathSlugStrategyPlugin
 {
@@ -43,12 +44,14 @@ class PathSlugStrategyPlugin
      * @param FilterManager $filterManager
      * @param UrlFactory $urlFactory
      * @param FilterSlugManager $filterSlugManager
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         LandingPageContext $landingPageContext,
         FilterManager $filterManager,
         UrlFactory $urlFactory,
-        FilterSlugManager $filterSlugManager
+        FilterSlugManager $filterSlugManager,
+        private readonly StoreManagerInterface $storeManager
     ) {
         $this->landingPageContext = $landingPageContext;
         $this->filterManager = $filterManager;
@@ -177,13 +180,17 @@ class PathSlugStrategyPlugin
         }
 
         $lookupTable = $this->filterSlugManager->getLookupTable();
+        $storeId = (int) $this->storeManager->getStore()->getId();
         $filters = [];
         foreach ($landingsPageFilters as $filter) {
             $filters[] = $filter->getFacet();
-            if (!empty($lookupTable[$filter->getValue()])) {
-                $filters[] = $lookupTable[$filter->getValue()];
+            $key = strtolower($filter->getValue());
+            if (!empty($lookupTable[$storeId][$key])) {
+                $filters[] = $lookupTable[$storeId][$key];
+            } elseif (!empty($lookupTable[0][$key])) {
+                $filters[] = $lookupTable[0][$key];
             } else {
-                $filters[] = strtolower($filter->getValue());
+                $filters[] = $key;
             }
         }
 


### PR DESCRIPTION
## Summary

When a landing page has "hide selected filters" enabled, the pre-applied filters are intentionally hidden from the visible filter state in the layered navigation. Because of this, when a visitor clicks a category facet link, the hidden filters have to be manually added back into the URL to keep them active. The code responsible for this was silently broken — it never actually looked up the correct URL slug for a filter value, so for values with special characters or spaces (like "Black / Zwart") the slug would not be resolved and the URL segment would contain the raw value including the space and slash, resulting in a malformed or non-functional URL.

- `afterGetCategoryFilterSelectUrl` in `PathSlugStrategyPlugin` was looking up filter value slugs using the filter value string as a top-level key in the slug lookup table (`$lookupTable[$filter->getValue()]`).
- The lookup table returned by `FilterSlugManager::getLookupTable()` is keyed as `[storeId][optionLabel_lowercase] => slug`. The top-level keys are **store IDs** (integers), not filter values. The old lookup therefore always evaluated to empty, meaning the slug table was never consulted and landing-page filter URLs were always built by naively lowercasing the raw filter value — producing broken URL segments for values that contain spaces, slashes, or special characters (e.g. `"Black / Zwart"` → `"black / zwart"` instead of `"black-zwart"`).
- Two open external PRs (#45 and #49) attempted to fix this but both still used the wrong top-level key and did not resolve the underlying issue.
- This fix injects `StoreManagerInterface` into `PathSlugStrategyPlugin` and corrects the lookup to use `$lookupTable[$storeId][$key]`, with a fallback to the global store scope (`$lookupTable[0][$key]`) mirroring the same pattern used in `FilterSlugManager::getAttributeBySlug()`.

## How to test

**Scenario 1 — Landing page filter URL is built correctly for a value with special characters**

Prerequisites: `PathSlugStrategy` is the active URL strategy (`tweakwise/layered/url_strategy`). A landing page exists with a pre-applied filter whose value contains a space or special character (e.g. colour `"Black / Zwart"`). A slug for that value exists in `tweakwise_attribute_slug` (e.g. `slug = "black-zwart"`).

1. Navigate to the landing page on the storefront.
2. Inspect the URL — it should contain the slug `black-zwart` as a path segment, not the raw lowercased value `black / zwart`.
3. Confirm the page loads without a 404 and the correct products are shown.

---

**Scenario 2 — Landing page filter URL falls back gracefully when no slug exists**

1. Delete or clear the `tweakwise_attribute_slug` table entries for the relevant filter value.
2. Navigate to the same landing page.
3. The URL segment should fall back to `strtolower($filter->getValue())` — no fatal error, no empty segment.

---

**Scenario 3 — Multi-store: slug resolved from correct store scope**

1. Set up two store views (e.g. store ID 1 and store ID 2) with different slugs for the same filter value in `tweakwise_attribute_slug`.
2. Visit the landing page on each store view.
3. Confirm each store view uses its own store-scoped slug, not the other store's slug or the global fallback.

---

**Scenario 4 — Regression: non-landing-page category/search pages are unaffected**

1. Navigate to a regular category page with `PathSlugStrategy` active.
2. Apply and remove filters using the layered navigation.
3. Confirm URL behaviour is identical to before — `afterGetCategoryFilterSelectUrl` returns early when no landing page is active.

---