### PR TITLE
fix: update canonical tag on AJAX navigation for landing pages

### DIFF
--- a/src/Plugin/Model/AjaxNavigationResultPlugin.php
+++ b/src/Plugin/Model/AjaxNavigationResultPlugin.php
@@ -126,4 +126,3 @@ class AjaxNavigationResultPlugin
             . '?' . http_build_query($query);
     }
 }
-

--- a/src/Plugin/Model/AjaxNavigationResultPlugin.php
+++ b/src/Plugin/Model/AjaxNavigationResultPlugin.php
@@ -87,8 +87,9 @@ class AjaxNavigationResultPlugin
         $page = (int) $this->request->getParam('p');
 
         // Admin-configured canonical override: never append ?p= to explicit overrides
-        if ($landingPage->getCanonicalUrl()) {
-            return $landingPage->getCanonicalUrl();
+        $canonicalUrl = $landingPage->getCanonicalUrl();
+        if ($canonicalUrl) {
+            return $canonicalUrl;
         }
 
         if ($this->alpConfig->isCanonicalSelfReferencingEnabled()) {

--- a/src/Plugin/Model/AjaxNavigationResultPlugin.php
+++ b/src/Plugin/Model/AjaxNavigationResultPlugin.php
@@ -2,12 +2,14 @@
 
 namespace Tweakwise\AttributeLandingTweakwise\Plugin\Model;
 
+use Emico\AttributeLanding\Model\Config as AlpConfig;
 use Emico\AttributeLanding\Model\LandingPageContext;
+use Magento\Framework\App\Request\Http as MagentoHttpRequest;
+use Magento\Store\Model\StoreManagerInterface;
 use Tweakwise\AttributeLandingTweakwise\Model\FilterManager;
 use Tweakwise\Magento2Tweakwise\Model\AjaxNavigationResult;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\UrlModel;
-use Magento\Framework\App\Request\Http as MagentoHttpRequest;
 
 class AjaxNavigationResultPlugin
 {
@@ -42,7 +44,9 @@ class AjaxNavigationResultPlugin
         LandingPageContext $landingPageContext,
         FilterManager $filterManager,
         Url $url,
-        UrlModel $urlModel
+        UrlModel $urlModel,
+        private readonly AlpConfig $alpConfig,
+        private readonly StoreManagerInterface $storeManager
     ) {
         $this->request = $request;
         $this->landingPageContext = $landingPageContext;
@@ -64,4 +68,62 @@ class AjaxNavigationResultPlugin
 
         return $proceed();
     }
+
+    /**
+     * @param AjaxNavigationResult $subject
+     * @param callable $proceed
+     * @param string $responseUrl
+     * @return string
+     */
+    public function aroundGetCanonicalUrl(AjaxNavigationResult $subject, callable $proceed, string $responseUrl): string
+    {
+        $type = $this->request->getParam('__tw_ajax_type');
+        $landingPage = $this->landingPageContext->getLandingPage();
+
+        if ($type !== 'landingpage' || !$landingPage) {
+            return $proceed($responseUrl);
+        }
+
+        $page = (int) $this->request->getParam('p');
+
+        // Admin-configured canonical override: never append ?p= to explicit overrides
+        if ($landingPage->getCanonicalUrl()) {
+            return $landingPage->getCanonicalUrl();
+        }
+
+        if ($this->alpConfig->isCanonicalSelfReferencingEnabled()) {
+            // Self-referencing: use full URL with current query params (filters), add ?p= when needed
+            return $this->appendPageParam($responseUrl, $page);
+        }
+
+        // Plain canonical: bare landing page URL + ?p= when needed
+        $baseUrl = $this->storeManager->getStore()->getUrl('', ['_direct' => $landingPage->getUrlPath()]);
+        return $this->appendPageParam($baseUrl, $page);
+    }
+
+    /**
+     * @param string $url
+     * @param int $page
+     * @return string
+     */
+    private function appendPageParam(string $url, int $page): string
+    {
+        if ($page < 2) {
+            return $url;
+        }
+
+        $urlParts = parse_url($url);
+        $query = [];
+        if (isset($urlParts['query'])) {
+            parse_str($urlParts['query'], $query);
+        }
+
+        $query['p'] = $page;
+
+        return (isset($urlParts['scheme']) ? $urlParts['scheme'] . '://' : '')
+            . ($urlParts['host'] ?? '')
+            . ($urlParts['path'] ?? '')
+            . '?' . http_build_query($query);
+    }
 }
+


### PR DESCRIPTION
Companion PR to [EmicoEcommerce/Magento2Tweakwise#389](https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/389).

The main module's `AjaxNavigationResult::getCanonicalUrl()` uses `getResponseUrl()` as the base URL. For landing pages this is intercepted by the bridge plugin to return the landing page URL — but the canonical logic still needed to respect Emico's own canonical configuration (hardcoded override, self-referencing mode, or bare URL mode).

Without this change, landing page AJAX responses would return a canonical based purely on the filter URL, ignoring the `canonical_url` column and the `emico_attributelanding/general/canonical_self_referencing` setting.

**Changes:**

- `src/Plugin/Model/AjaxNavigationResultPlugin.php` — adds `aroundGetCanonicalUrl()` that intercepts canonical generation for landing page AJAX requests. Mirrors Emico's `SeoObserver::getCanonicalUrl()` priority logic:
  1. If the landing page has a hardcoded `canonical_url` set in admin → return it as-is (no `?p=` appended).
  2. If `isCanonicalSelfReferencingEnabled()` → use the filter-aware response URL + `?p=N` when paginated.
  3. Otherwise → bare landing page URL + `?p=N` when paginated.
  Falls through to `$proceed()` for non-landing-page requests.

## How to test

**Scenario 1 — Landing page AJAX canonical, self-referencing off**

1. Set `tweakwise/seo/paginated_canonical_enabled = 1`, `emico_attributelanding/general/canonical_self_referencing = 0`. Run `cache:clean`.
2. Open a landing page with AJAX filters enabled.
3. Apply a filter. Canonical in DOM should be the bare landing page URL (no filter query params).
4. Navigate to page 2. Canonical should include `?p=2`.

---

**Scenario 2 — Landing page AJAX canonical, self-referencing on**

1. Set `emico_attributelanding/general/canonical_self_referencing = 1`. Run `cache:clean`.
2. Apply a filter on a landing page. Canonical should include the active filter query params.
3. Navigate to page 2. Canonical should include both filter params and `?p=2`.

---

**Scenario 3 — Landing page with hardcoded canonical_url**

1. Set a `canonical_url` value on a landing page in the admin.
2. Apply filters and navigate pages via AJAX.
3. Canonical should always remain the hardcoded value regardless of filters or page number.

---